### PR TITLE
SendMessageTimeout function signature.

### DIFF
--- a/jcl/jcl/source/common/JclSysInfo.pas
+++ b/jcl/jcl/source/common/JclSysInfo.pas
@@ -2982,7 +2982,7 @@ end;
 
 function IsWindowResponding(Wnd: THandle; Timeout: Integer): Boolean;
 var
-  Res: DWORD;
+  Res: QWORD;
 begin
   Res := 0;
   Result := SendMessageTimeout(Wnd, WM_NULL, 0, 0, SMTO_ABORTIFHUNG, Timeout, {$IFDEF RTL230_UP}@{$ENDIF}Res) <> 0;


### PR DESCRIPTION
FPC trunk ( as of 04 May 2019 ) has changed the SendMessageTimeout signature ( i think ). Had to make this change for compilation.,